### PR TITLE
Fix compilation errors after upgrading maven-filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
     <maven-pmd-plugin.version>3.17.0</maven-pmd-plugin.version>
     <maven-project-info-reports-plugin.version>3.3.0</maven-project-info-reports-plugin.version>
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+    <maven-shared-utils.version>3.2.1</maven-shared-utils.version>
     <maven-site-plugin.version>3.12.0</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
@@ -195,7 +196,12 @@
         <artifactId>maven-filtering</artifactId>
         <version>${maven-filtering.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.apache.maven.shared</groupId>
+        <artifactId>maven-shared-utils</artifactId>
+        <version>${maven-shared-utils.version}</version>
+      </dependency>
+      
       <!-- third party dependencies -->
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -230,6 +236,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
@@ -238,6 +249,11 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFiltering.java
+++ b/src/main/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFiltering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 Polago AB.
+ * Copyright 2014-2022 Polago AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.FilterWrapper;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
@@ -65,8 +66,6 @@ import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 import org.apache.maven.shared.utils.PathTool;
 import org.apache.maven.shared.utils.ReaderFactory;
 import org.apache.maven.shared.utils.StringUtils;
-import org.apache.maven.shared.utils.io.FileUtils;
-import org.apache.maven.shared.utils.io.FileUtils.FilterWrapper;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
@@ -269,7 +268,7 @@ public class MergeProperitesMavenResourcesFiltering extends AbstractLogEnabled
      */
     private void handleDefaultFilterWrappers(MavenResourcesExecution mavenResourcesExecution)
         throws MavenFilteringException {
-        List<FileUtils.FilterWrapper> filterWrappers = new ArrayList<FileUtils.FilterWrapper>();
+        List<FilterWrapper> filterWrappers = new ArrayList<>();
         if (mavenResourcesExecution.getFilterWrappers() != null) {
             filterWrappers.addAll(mavenResourcesExecution.getFilterWrappers());
         }

--- a/src/test/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFilteringTest.java
+++ b/src/test/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFilteringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1014-2016 Polago AB.
+ * Copyright 1014-2022 Polago AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,9 @@ import java.util.Properties;
 
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.testing.SilentLog;
+import org.apache.maven.shared.filtering.FilterWrapper;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
-import org.apache.maven.shared.utils.io.FileUtils.FilterWrapper;
 import org.codehaus.plexus.util.Scanner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- Use FilterWrapper from maven-filtering
- Add dependencies of maven-core and maven-shared-utils
