### PR TITLE
Fix maven 3.9.2 warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- - Copyright 2014-2022 Polago AB.
+ - Copyright 2014-2023 Polago AB.
  -
  - Licensed under the Apache License, Version 2.0 (the "License");
  - you may not use this file except in compliance with the License.
@@ -146,6 +146,7 @@
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+    <sisu-maven-plugin.version>0.3.5</sisu-maven-plugin.version>
     <taglist-maven-plugin.version>3.0.0</taglist-maven-plugin.version>
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
 
@@ -153,6 +154,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+        <scope>provided</scope>
+      </dependency>
+
       <!-- Maven plugin dependencies -->
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -200,7 +208,7 @@
         <artifactId>maven-shared-utils</artifactId>
         <version>${maven-shared-utils.version}</version>
       </dependency>
-      
+
       <!-- third party dependencies -->
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -417,6 +425,12 @@
         </plugin>
 
         <plugin>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>sisu-maven-plugin</artifactId>
+          <version>${sisu-maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>${maven-site-plugin.version}</version>
@@ -510,6 +524,21 @@
           <goalPrefix>merge-properties</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <?m2e execute onIncremental?>
+            <id>generate-index</id>
+            <goals>
+              <goal>main-index</goal>
+              <goal>test-index</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
     <groovy.version>3.0.17</groovy.version>
     <junit.version>5.9.3</junit.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-    <plexus-component-metadata.version>2.1.1</plexus-component-metadata.version>
     <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
 
     <!-- plugins -->
@@ -468,12 +467,6 @@
         </plugin>
 
         <plugin>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-metadata</artifactId>
-          <version>${plexus-component-metadata.version}</version>
-        </plugin>
-
-        <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>${nexus-staging-maven-plugin.version}</version>
@@ -517,19 +510,6 @@
           <goalPrefix>merge-properties</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-        <executions>
-          <execution>
-            <?m2e ignore?>
-            <goals>
-              <goal>generate-metadata</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>

--- a/src/main/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFiltering.java
+++ b/src/main/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFiltering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Polago AB.
+ * Copyright 2014-2023 Polago AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,15 +49,17 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.TreeMap;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.PropertiesConfigurationLayout;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.filtering.FilterWrapper;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
@@ -66,8 +68,6 @@ import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 import org.apache.maven.shared.utils.PathTool;
 import org.apache.maven.shared.utils.ReaderFactory;
 import org.apache.maven.shared.utils.StringUtils;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
@@ -78,7 +78,8 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 /**
  * MavenResourcesFiltering Plexus Component that merges properties into a single file.
  */
-@Component(role = MavenResourcesFiltering.class, hint = "merge")
+@Named("merge")
+@Singleton
 public class MergeProperitesMavenResourcesFiltering extends AbstractLogEnabled
     implements MavenResourcesFiltering, Initializable {
 
@@ -88,21 +89,26 @@ public class MergeProperitesMavenResourcesFiltering extends AbstractLogEnabled
 
     private List<String> defaultNonFilteredFileExtensions;
 
-    @Requirement(hint = "default")
-    private MavenFileFilter mavenFileFilter;
+    private final MavenFileFilter mavenFileFilter;
 
-    @Requirement
     private BuildContext buildContext;
-
-    @Requirement
-    private MavenSession session;
-
-    @Requirement
-    private MavenProject project;
 
     private String outputFile;
 
     private boolean overwriteProperties = false;
+
+    /**
+     * Public Constructor.
+     *
+     * @param mavenFileFilter the {@link MavenFileFilter} to use
+     * @param buildContext the {@link BuildContext} to use
+     */
+    @Inject
+    public MergeProperitesMavenResourcesFiltering(MavenFileFilter mavenFileFilter, BuildContext buildContext) {
+        super();
+        this.mavenFileFilter = mavenFileFilter;
+        this.buildContext = buildContext;
+    }
 
     /**
      * {@inheritDoc}

--- a/src/test/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFilteringTest.java
+++ b/src/test/java/org/polago/maven/plugins/mergeproperties/MergeProperitesMavenResourcesFilteringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1014-2022 Polago AB.
+ * Copyright 2014-2023 Polago AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,15 @@ import java.util.Properties;
 
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.testing.SilentLog;
+import org.apache.maven.shared.filtering.DefaultMavenFileFilter;
 import org.apache.maven.shared.filtering.FilterWrapper;
+import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
 import org.codehaus.plexus.util.Scanner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.sonatype.plexus.build.incremental.BuildContext;
 import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 
 /**
@@ -50,6 +53,10 @@ public class MergeProperitesMavenResourcesFilteringTest {
         Properties storedProperties = null;
 
         File storedFile = null;
+
+        public TestMergeProperitesMavenResourcesFiltering(MavenFileFilter mavenFileFilter, BuildContext buildContext) {
+            super(mavenFileFilter, buildContext);
+        }
 
         /**
          * {@inheritDoc}
@@ -130,7 +137,8 @@ public class MergeProperitesMavenResourcesFilteringTest {
 
     @BeforeEach
     public void setUp() {
-        filtering = new TestMergeProperitesMavenResourcesFiltering();
+        filtering =
+            new TestMergeProperitesMavenResourcesFiltering(new DefaultMavenFileFilter(buildContext), buildContext);
         filtering.enableLogging(new SilentLog());
         filtering.setOutputFile(outputFile);
         filtering.setBuildContext(buildContext);

--- a/src/test/java/org/polago/maven/plugins/mergeproperties/MergePropertiesMojoTest.java
+++ b/src/test/java/org/polago/maven/plugins/mergeproperties/MergePropertiesMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1014-2016 Polago AB.
+ * Copyright 2014-2023 Polago AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.maven.plugin.testing.SilentLog;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.DefaultMavenFileFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.sonatype.plexus.build.incremental.BuildContext;
+import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 
 /**
  * Tests the {@link MergePropertiesMojo} class.
@@ -34,7 +37,10 @@ public class MergePropertiesMojoTest {
     @BeforeEach
     public void setUp() {
         mojo = new MergePropertiesMojo();
-        MergeProperitesMavenResourcesFiltering filtering = new MergeProperitesMavenResourcesFiltering();
+        BuildContext buildContext = new DefaultBuildContext();
+
+        MergeProperitesMavenResourcesFiltering filtering =
+            new MergeProperitesMavenResourcesFiltering(new DefaultMavenFileFilter(buildContext), buildContext);
         filtering.enableLogging(new SilentLog());
         mojo.setMavenResourcesFiltering(filtering);
 


### PR DESCRIPTION
- Remove plexus-component-metadata dependency
- Use JSR-330 annotation instead of @Component
- Remove Plexus dependency from MergePropertiesMojo
