### PR TITLE
Improve groovy dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -974,7 +974,7 @@
                   <goal>install</goal>
                   <goal>run</goal>
                 </goals>
-              </execution>              
+              </execution>
             </executions>
             <configuration>
               <projectsDirectory>src/it</projectsDirectory>
@@ -990,6 +990,19 @@
                 <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy</artifactId>
                 <version>${groovy.version}</version>
+                <scope>runtime</scope>
+              </dependency>
+              <dependency>
+                <groupId>org.apache.groovy</groupId>
+                <artifactId>groovy-json</artifactId>
+                <version>${groovy.version}</version>
+                <scope>runtime</scope>
+              </dependency>
+              <dependency>
+                <groupId>org.apache.groovy</groupId>
+                <artifactId>groovy-xml</artifactId>
+                <version>${groovy.version}</version>
+                <scope>runtime</scope>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
To align with default groovy dependencies, lets override groovy-json and
groovy-xml in addition to groovy core